### PR TITLE
add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,62 @@
+---
+name: Issue padrão
+about: Template para abertura de issues no repositório
+title: '[Tipo]: Breve descrição da issue'
+labels: ''
+assignees: ''
+---
+
+### **Descrição**
+
+<!-- Forneça uma descrição clara e concisa do problema ou solicitação. -->
+
+**Contexto:**
+
+<!-- Explique o que está acontecendo atualmente. -->
+
+**Comportamento esperado:**
+
+<!-- Descreva o que deveria acontecer. -->
+
+**Passos para reproduzir:**
+
+<!-- Liste os passos para reproduzir o problema. -->
+
+1. ...
+2. ...
+3. ...
+
+### **Ambiente**
+
+<!-- Informe os detalhes do ambiente em que o problema ocorreu. -->
+
+-   **Sistema operacional:**
+-   **Navegador/Versão (se aplicável):**
+-   **Versão do sistema/aplicação:**
+-   **Outros detalhes relevantes:**
+
+---
+
+### **Anexos**
+
+<!-- Adicione capturas de tela, logs ou outros arquivos que possam ajudar na investigação. -->
+
+-   [ ] Imagens ou logs adicionados.
+
+---
+
+### **Checklist**
+
+Antes de abrir esta issue, confirme se:
+
+-   [ ] Verifiquei se esta issue já existe.
+-   [ ] Incluí uma descrição completa e passos para reproduzir.
+-   [ ] Adicionei todas as informações relevantes, incluindo ambiente e anexos.
+-   [ ] Classifiquei a prioridade da issue (baixa, média, alta).
+-   [ ] Adicionei labels relevantes para categorizar a issue.
+
+---
+
+### **Informações adicionais**
+
+<!-- Inclua aqui qualquer detalhe ou contexto adicional que possa ser relevante. -->


### PR DESCRIPTION
Adicionado o arquivo ISSUE_TEMPLATE.md no diretório .github/ISSUE_TEMPLATE para padronizar a abertura de issues no repositório.